### PR TITLE
Add needed permissions to ci role for ecr upload

### DIFF
--- a/.github/workflows/ci_build.yml
+++ b/.github/workflows/ci_build.yml
@@ -51,7 +51,7 @@ jobs:
         uses: aws-actions/configure-aws-credentials@v2
         with:
           role-to-assume: ${{ secrets.AWS_IAM_ROLE_ARN }}
-          role-session-name: samplerolesession
+          role-session-name: ecr-upload-session
           aws-region: ${{ secrets.AWS_REGION }}
 
       - name: Login to AWS ECR

--- a/infrastructure/repo.tf
+++ b/infrastructure/repo.tf
@@ -67,10 +67,30 @@ resource "aws_iam_role_policy" "repo-ecr-upload" {
 data "aws_iam_policy_document" "repo-ecr-upload" {
   statement {
     actions = [
-      "ecr:GetAuthorizationToken",
       "ecr:PutImage",
+      "ecr:BatchCheckLayerAvailability",
+      "ecr:InitiateLayerUpload",
+      "ecr:UploadLayerPart",
+      "ecr:CompleteLayerUpload",
     ]
 
     resources = [aws_ecr_repository.garden-of-intelligence.arn]
   }
 }
+
+resource "aws_iam_role_policy" "repo-ecr-auth" {
+  role   = aws_iam_role.repo.name
+  name   = "ecr-${var.APP_NAME}-ci-auth"
+  policy = data.aws_iam_policy_document.repo-ecr-auth.json
+}
+
+data "aws_iam_policy_document" "repo-ecr-auth" {
+  statement {
+    actions = [
+      "ecr:GetAuthorizationToken",
+    ]
+
+    resources = ["*"]
+  }
+}
+


### PR DESCRIPTION
The role that the ci job assumes needs the permissions to authenticate and upload to the ecr repo.